### PR TITLE
Fix deprecated interpolation-only expressions

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -5,67 +5,67 @@
 resource "aws_instance" "ams_5015" {
   ami                         = "ami-06d51e91cea0dac8d"
   instance_type               = "t2.micro"
-  key_name                    = "${aws_key_pair.default.key_name}"
-  subnet_id                   = "${aws_subnet.ams_a.id}"
-  user_data                   = "${file("cloud-init.sh")}"
-  vpc_security_group_ids      = ["${aws_security_group.ams.id}"]
+  key_name                    = aws_key_pair.default.key_name
+  subnet_id                   = aws_subnet.ams_a.id
+  user_data                   = file("cloud-init.sh")
+  vpc_security_group_ids      = [aws_security_group.ams.id]
 }
 
 resource "aws_eip" "ams_5015" {
-  instance = "${aws_instance.ams_5015.id}"
+  instance = aws_instance.ams_5015.id
 }
 
 output "ams_5015_public_dns" {
-  value = "${aws_eip.ams_5015.public_dns}"
+  value = aws_eip.ams_5015.public_dns
 }
 
 output "ams_5015_public_ip" {
-  value = "${aws_eip.ams_5015.public_ip}"
+  value = aws_eip.ams_5015.public_ip
 }
 
 resource "aws_instance" "ams_demo" {
   ami                         = "ami-06d51e91cea0dac8d"
   instance_type               = "t2.micro"
-  key_name                    = "${aws_key_pair.default.key_name}"
-  subnet_id                   = "${aws_subnet.ams_a.id}"
-  user_data                   = "${file("cloud-init.sh")}"
-  vpc_security_group_ids      = ["${aws_security_group.ams.id}"]
+  key_name                    = aws_key_pair.default.key_name
+  subnet_id                   = aws_subnet.ams_a.id
+  user_data                   = file("cloud-init.sh")
+  vpc_security_group_ids      = [aws_security_group.ams.id]
 }
 
 resource "aws_eip" "ams_demo" {
-  instance = "${aws_instance.ams_demo.id}"
+  instance = aws_instance.ams_demo.id
 }
 
 output "ams_demo_public_dns" {
-  value = "${aws_eip.ams_demo.public_dns}"
+  value = aws_eip.ams_demo.public_dns
 }
 
 output "ams_demo_public_ip" {
-  value = "${aws_eip.ams_demo.public_ip}"
+  value = aws_eip.ams_demo.public_ip
 }
 
 resource "aws_instance" "livefeed_demo" {
   ami                         = "ami-06d51e91cea0dac8d"
   instance_type               = "t2.micro"
-  key_name                    = "${aws_key_pair.default.key_name}"
-  subnet_id                   = "${aws_subnet.ams_a.id}"
-  user_data                   = "${file("livefeed-cloud-init.sh")}"
-  vpc_security_group_ids      = ["${aws_security_group.ams.id}"]
+  key_name                    = aws_key_pair.default.key_name
+  subnet_id                   = aws_subnet.ams_a.id
+  user_data                   = file("livefeed-cloud-init.sh")
+  vpc_security_group_ids      = [aws_security_group.ams.id]
 }
 
 resource "aws_eip" "livefeed_demo" {
-  instance = "${aws_instance.livefeed_demo.id}"
+  instance = aws_instance.livefeed_demo.id
 }
 
 output "livefeed_demo_public_dns" {
-  value = "${aws_eip.livefeed_demo.public_dns}"
+  value = aws_eip.livefeed_demo.public_dns
 }
 
 output "livefeed_demo_public_ip" {
-  value = "${aws_eip.livefeed_demo.public_ip}"
+  value = aws_eip.livefeed_demo.public_ip
 }
 
 resource "aws_key_pair" "default" {
   key_name   = "default ssh key"
-  public_key = "${var.ssh_public_key}"
+  public_key = var.ssh_public_key
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,17 +1,17 @@
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 }
 
 resource "aws_route" "default" {
-    route_table_id = "${aws_vpc.default.main_route_table_id}"
+    route_table_id = aws_vpc.default.main_route_table_id
     destination_cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.default.id}"
+    gateway_id = aws_internet_gateway.default.id
 }
 
 resource "aws_security_group" "ams" {
   name = "ams"
   description = "Base security group for AMS instances"
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   egress {
     description = "allow egress to anywhere"
@@ -67,19 +67,19 @@ resource "aws_security_group" "ams" {
     protocol  = "icmp"
     from_port = -1
     to_port   = -1
-    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
+    cidr_blocks = [aws_vpc.default.cidr_block]
   }
 
   egress {
     protocol  = "icmp"
     from_port = -1
     to_port   = -1
-    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
+    cidr_blocks = [aws_vpc.default.cidr_block]
   }
 }
 
 resource "aws_subnet" "ams_a" {
-  vpc_id            = "${aws_vpc.default.id}"
+  vpc_id            = aws_vpc.default.id
   cidr_block        = "192.168.0.0/24"
   availability_zone = "us-west-2a"
 }


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.